### PR TITLE
chore: update dependabot configuration to run once a month instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
         patterns:
           - "*" # Group all GitHub Actions dependencies together
     schedule:
-      interval: "weekly"
+      interval: monthly
       day: "monday"
       time: "09:00"
       timezone: "Etc/UTC"


### PR DESCRIPTION
Update depandabot configuration to run once a month instead of weekly.

See https://github.com/humanitec/multi-gitter/pull/19 for more details.